### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,50 @@
+pull_request_rules:
+  - name: Assign t-shirt size to PR
+    description: Assign a t-shirt size label to a pull request based on the number
+      of lines changed.
+    conditions:
+      - "#modified-lines >= 100"
+      - "#modified-lines < 500"
+    actions:
+      label:
+        toggle:
+          - size/L
+  - name: Label conflicting pull requests
+    description: Add a label to a pull request with conflict to spot it easily
+    conditions:
+      - conflict
+      - -closed
+    actions:
+      label:
+        toggle:
+          - conflict
+  - name: Ping PR author when conflicting
+    description: Warn the pull request author when their PR are conflicting
+    conditions:
+      - conflict
+      - -closed
+    actions:
+      comment:
+        message: >
+          👋 {{author}} your PR is conflicting and needs to be updated to be
+          merged
+  - name: Make sure PR are up to date before merging
+    description: This automatically updates PRs when they are out-of-date with the
+      base branch to avoid semantic conflicts (next step is using a merge
+      queue).
+    conditions: []
+    actions:
+      update:
+  - name: Notify when a PR is removed from the queue
+    description: Notify the PR author when its pull request is removed from the merge queue.
+    conditions:
+      - queue-dequeue-reason != none
+      - queue-dequeue-reason != pr-merged
+    actions:
+      comment:
+        message: >
+          Hey @{{author}}, your pull request has been dequeued due to the
+          following reason: {{queue_dequeue_reason}}.
+
+          Sorry about that, but you can requeue the PR by using `@mergifyio
+          requeue` if you think this was a mistake.

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -40,7 +40,8 @@ pull_request_rules:
     description: This automatically updates PRs when they are out-of-date with the
       base branch to avoid semantic conflicts (next step is using a merge
       queue).
-    conditions: []
+    conditions:
+      - base-sha-mismatch
     actions:
       update:
   - name: Notify when a PR is removed from the queue

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,14 @@ pull_request_rules:
       label:
         toggle:
           - size/L
+  - name: Assign XL t-shirt size to large PRs
+    description: Assign a t-shirt size label to a pull request with 500 or more modified lines.
+    conditions:
+      - "#modified-lines >= 500"
+    actions:
+      label:
+        toggle:
+          - size/XL
   - name: Label conflicting pull requests
     description: Add a label to a pull request with conflict to spot it easily
     conditions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,7 +19,7 @@ pull_request_rules:
         toggle:
           - conflict
   - name: Ping PR author when conflicting
-    description: Warn the pull request author when their PR are conflicting
+    description: Warn the pull request author when their PR is conflicting
     conditions:
       - conflict
       - -closed

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,14 +9,6 @@ pull_request_rules:
       label:
         toggle:
           - size/L
-  - name: Assign XL t-shirt size to large PRs
-    description: Assign a t-shirt size label to a pull request with 500 or more modified lines.
-    conditions:
-      - "#modified-lines >= 500"
-    actions:
-      label:
-        toggle:
-          - size/XL
   - name: Label conflicting pull requests
     description: Add a label to a pull request with conflict to spot it easily
     conditions:
@@ -40,8 +32,7 @@ pull_request_rules:
     description: This automatically updates PRs when they are out-of-date with the
       base branch to avoid semantic conflicts (next step is using a merge
       queue).
-    conditions:
-      - base-sha-mismatch
+    conditions: []
     actions:
       update:
   - name: Notify when a PR is removed from the queue


### PR DESCRIPTION
This change has been made by @awfixer from the Mergify workflow automation editor.

## Summary by Sourcery

Configure Mergify to automate PR maintenance by adding rules for size labeling, conflict handling, branch updates, and dequeue notifications

CI:
- Add rule to assign size/L label to PRs with 100–499 modified lines
- Add rules to label conflicting PRs and notify authors via comment
- Add auto-update rule to keep PR branches in sync with the base
- Add rule to comment and notify authors when their PR is removed from the merge queue